### PR TITLE
Change Organization ID expected type back to int

### DIFF
--- a/digicert/organizations.go
+++ b/digicert/organizations.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Organization struct {
-	ID          int        `json:"id,string,omitempty"` // NOTE: this value sometimes come back as as string?
+	ID          int        `json:"id,omitempty"` // NOTE: this value sometimes come back as as string?
 	Status      string     `json:"status,omitempty"`
 	Name        string     `json:"name,omitempty"`
 	AssumedName string     `json:"assumed_name,omitempty"`


### PR DESCRIPTION
The Digicert API inexplicably began returning the Organization ID
attribute as a string earlier this week, and it has switched back to an
int. Considering it was the only ID attribute being returned as string,
I believe this is the correct, intended state.

A future todo is to explore the json.Number type and see if that helps
us be a bit more flexible and resilient to quirks like this.